### PR TITLE
Remove tag protection

### DIFF
--- a/github/repository/main.tf
+++ b/github/repository/main.tf
@@ -69,8 +69,3 @@ resource "github_branch_protection" "all" {
   require_signed_commits = true
   allows_deletions = true
 }
-
-resource "github_repository_tag_protection" "all" {
-  repository = github_repository.this.name
-  pattern = "*"
-}


### PR DESCRIPTION
We are removing tag protection because it stops us from updating floating tags automatically in GitHub Actions.